### PR TITLE
Daily withdrawal limit feature

### DIFF
--- a/src/main/AccountHandler.java
+++ b/src/main/AccountHandler.java
@@ -169,6 +169,10 @@ public class AccountHandler {
             double availableFunds = account.getBalance() + checking.getOverdraftLimit();
             System.out.println("Available to withdraw: $" + String.format("%.2f", availableFunds));
         }
+        if (account.hasDailyWithdrawalLimit()) {
+            System.out.println("Daily limit: $" + String.format("%.2f", account.getDailyWithdrawalLimit())
+                + " (remaining today: $" + String.format("%.2f", account.getDailyWithdrawalRemaining()) + ")");
+        }
         return true;
     }
 

--- a/src/main/AccountSettingsHandler.java
+++ b/src/main/AccountSettingsHandler.java
@@ -99,6 +99,40 @@ public class AccountSettingsHandler {
         System.out.println("=======================\n");
     }
 
+    public void manageDailyWithdrawalLimit() {
+        int idx = inputHelper.selectOpenAccount("Select account to manage daily withdrawal limit:");
+        if (idx == -1) return;
+        BankAccount account = accounts.get(idx);
+        if (!inputHelper.authenticateAccount(account)) return;
+        if (account.hasDailyWithdrawalLimit()) {
+            modifyExistingDailyLimit(account);
+        } else {
+            createNewDailyLimit(account);
+        }
+    }
+
+    private void modifyExistingDailyLimit(BankAccount account) {
+        System.out.println("\nCurrent daily withdrawal limit: $" + String.format("%.2f", account.getDailyWithdrawalLimit()));
+        System.out.println("Used today: $" + String.format("%.2f", account.getDailyWithdrawalUsedToday()));
+        System.out.println("1. Change limit");
+        System.out.println("2. Remove limit");
+        int choice = inputHelper.getUserSelection(2);
+        if (choice == 1) {
+            double newLimit = inputHelper.getPositiveAmount("Enter new daily withdrawal limit: $");
+            account.setDailyWithdrawalLimit(newLimit);
+            System.out.println("Daily withdrawal limit updated to $" + String.format("%.2f", newLimit) + ".");
+        } else {
+            account.clearDailyWithdrawalLimit();
+            System.out.println("Daily withdrawal limit removed.");
+        }
+    }
+
+    private void createNewDailyLimit(BankAccount account) {
+        double limit = inputHelper.getPositiveAmount("Enter daily withdrawal limit: $");
+        account.setDailyWithdrawalLimit(limit);
+        System.out.println("Daily withdrawal limit set to $" + String.format("%.2f", limit) + ".");
+    }
+
     public void displayCombinedSummary() {
         System.out.println("\n========== Combined Account Summary ==========");
         System.out.println("Total Accounts:    " + summaryGenerator.getTotalAccountCount()

--- a/src/main/BankAccount.java
+++ b/src/main/BankAccount.java
@@ -1,5 +1,6 @@
 package main;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,6 +12,9 @@ public class BankAccount {
     private double fees;
     private String pin;
     private String nickname;
+    private double dailyWithdrawalLimit;
+    private double dailyWithdrawalUsed;
+    private LocalDate lastWithdrawalDate;
 
     public BankAccount() {
         this.balance = 0;
@@ -19,6 +23,9 @@ public class BankAccount {
         this.fees = 0;
         this.pin = null;
         this.nickname = null;
+        this.dailyWithdrawalLimit = 0;
+        this.dailyWithdrawalUsed = 0;
+        this.lastWithdrawalDate = null;
     }
 
     public void deposit(double amount) {
@@ -43,8 +50,10 @@ public class BankAccount {
         if (amount > this.balance) {
             throw new IllegalArgumentException();
         }
+        checkDailyWithdrawalLimit(amount);
         this.balance -= amount;
         this.transactions.add("Withdrawal: -$" + String.format("%.2f", amount));
+        recordDailyWithdrawal(amount);
     }
 
     public void takeLoan(double amount) {
@@ -212,4 +221,63 @@ public List<String> searchTransactions(String keyword) {
     
     return searchResults;
 }
+
+    public void setDailyWithdrawalLimit(double amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("Daily withdrawal limit must be greater than zero.");
+        }
+        this.dailyWithdrawalLimit = amount;
+    }
+
+    public void clearDailyWithdrawalLimit() {
+        this.dailyWithdrawalLimit = 0;
+        this.dailyWithdrawalUsed = 0;
+        this.lastWithdrawalDate = null;
+    }
+
+    public boolean hasDailyWithdrawalLimit() {
+        return this.dailyWithdrawalLimit > 0;
+    }
+
+    public double getDailyWithdrawalLimit() {
+        return this.dailyWithdrawalLimit;
+    }
+
+    public double getDailyWithdrawalUsedToday() {
+        if (lastWithdrawalDate == null || !lastWithdrawalDate.equals(LocalDate.now())) {
+            return 0;
+        }
+        return this.dailyWithdrawalUsed;
+    }
+
+    public double getDailyWithdrawalRemaining() {
+        if (!hasDailyWithdrawalLimit()) {
+            return Double.MAX_VALUE;
+        }
+        return this.dailyWithdrawalLimit - getDailyWithdrawalUsedToday();
+    }
+
+    protected void checkDailyWithdrawalLimit(double amount) {
+        if (!hasDailyWithdrawalLimit()) {
+            return;
+        }
+        if (getDailyWithdrawalUsedToday() + amount > this.dailyWithdrawalLimit) {
+            throw new IllegalStateException("Daily withdrawal limit would be exceeded. Limit: $"
+                + String.format("%.2f", this.dailyWithdrawalLimit)
+                + ", Remaining today: $"
+                + String.format("%.2f", getDailyWithdrawalRemaining()));
+        }
+    }
+
+    protected void recordDailyWithdrawal(double amount) {
+        if (!hasDailyWithdrawalLimit()) {
+            return;
+        }
+        LocalDate today = LocalDate.now();
+        if (lastWithdrawalDate == null || !lastWithdrawalDate.equals(today)) {
+            this.dailyWithdrawalUsed = 0;
+        }
+        this.dailyWithdrawalUsed += amount;
+        this.lastWithdrawalDate = today;
+    }
 }

--- a/src/main/CheckingAccount.java
+++ b/src/main/CheckingAccount.java
@@ -21,12 +21,14 @@ public class CheckingAccount extends BankAccount {
         if (amount > this.balance + OVERDRAFT_LIMIT) {
             throw new IllegalArgumentException();
         }
+        checkDailyWithdrawalLimit(amount);
         this.balance -= amount;
         this.transactions.add("Withdrawal: -$" + String.format("%.2f", amount));
         if (this.balance < 0) {
             this.balance -= OVERDRAFT_FEE;
             this.transactions.add("Overdraft Fee: -$" + String.format("%.2f", OVERDRAFT_FEE));
         }
+        recordDailyWithdrawal(amount);
     }
 
     public double getOverdraftLimit() {

--- a/src/main/MainMenu.java
+++ b/src/main/MainMenu.java
@@ -8,9 +8,9 @@ import java.util.Scanner;
 
 public class MainMenu {
 
-    private static final int EXIT_WITH_SAVE = 14;
-    private static final int EXIT_WITHOUT_SAVE = 15;
-    private static final int MAX_SELECTION = 15;
+    private static final int EXIT_WITH_SAVE = 15;
+    private static final int EXIT_WITHOUT_SAVE = 16;
+    private static final int MAX_SELECTION = 16;
 
     private ArrayList<BankAccount> accounts;
     private InputHelper inputHelper;
@@ -40,8 +40,9 @@ public class MainMenu {
         System.out.println("11. Take out a loan");
         System.out.println("12. View account summary");
         System.out.println("13. View combined summary (all accounts)");
-        System.out.println("14. Save and Exit");
-        System.out.println("15. Exit without saving");
+        System.out.println("14. Manage daily withdrawal limit");
+        System.out.println("15. Save and Exit");
+        System.out.println("16. Exit without saving");
     }
 
     public void processInput(int selection) {
@@ -59,6 +60,7 @@ public class MainMenu {
             case 11: settingsHandler.performLoan(); break;
             case 12: settingsHandler.displayAccountSummary(); break;
             case 13: settingsHandler.displayCombinedSummary(); break;
+            case 14: settingsHandler.manageDailyWithdrawalLimit(); break;
             case EXIT_WITH_SAVE: saveAndExit(); break;
             case EXIT_WITHOUT_SAVE: break;
         }

--- a/src/main/SavingsAccount.java
+++ b/src/main/SavingsAccount.java
@@ -61,10 +61,11 @@ public class SavingsAccount extends BankAccount {
         if (amount > this.balance) {
             throw new IllegalArgumentException("Insufficient funds.");
         }
-        
+        checkDailyWithdrawalLimit(amount);
         this.balance -= amount;
         this.transactions.add("Withdrawal: -$" + String.format("%.2f", amount));
         withdrawalCount++;
+        recordDailyWithdrawal(amount);
     }
     
     @Override

--- a/src/test/BankAccountTest.java
+++ b/src/test/BankAccountTest.java
@@ -486,4 +486,88 @@ public class BankAccountTest {
 		assertEquals("Groceries", testAccount.getNickname());
 	}
 
+	// 39. An account should not have a daily withdrawal limit by default
+	@Test
+	void testNoDailyWithdrawalLimitByDefault() {
+		assertFalse(testAccount.hasDailyWithdrawalLimit());
+	}
+
+	// 40. Setting a valid daily withdrawal limit should store it
+	@Test
+	void testSetDailyWithdrawalLimit() {
+		testAccount.setDailyWithdrawalLimit(100);
+		assertTrue(testAccount.hasDailyWithdrawalLimit());
+		assertEquals(100, testAccount.getDailyWithdrawalLimit(), 0.01);
+	}
+
+	// 41. Setting a non-positive daily withdrawal limit should throw
+	@Test
+	void testSetInvalidDailyWithdrawalLimit() {
+		assertThrows(IllegalArgumentException.class, () -> {
+			testAccount.setDailyWithdrawalLimit(0);
+		});
+		assertThrows(IllegalArgumentException.class, () -> {
+			testAccount.setDailyWithdrawalLimit(-50);
+		});
+	}
+
+	// 42. Clearing a daily withdrawal limit should remove it
+	@Test
+	void testClearDailyWithdrawalLimit() {
+		testAccount.setDailyWithdrawalLimit(100);
+		testAccount.clearDailyWithdrawalLimit();
+		assertFalse(testAccount.hasDailyWithdrawalLimit());
+	}
+
+	// 43. A withdrawal within the daily limit should succeed
+	@Test
+	void testWithdrawWithinDailyLimit() {
+		testAccount.deposit(500);
+		testAccount.setDailyWithdrawalLimit(200);
+		testAccount.withdraw(150);
+		assertEquals(350, testAccount.getBalance(), 0.01);
+		assertEquals(150, testAccount.getDailyWithdrawalUsedToday(), 0.01);
+		assertEquals(50, testAccount.getDailyWithdrawalRemaining(), 0.01);
+	}
+
+	// 44. A withdrawal exceeding the daily limit should throw
+	@Test
+	void testWithdrawExceedsDailyLimit() {
+		testAccount.deposit(500);
+		testAccount.setDailyWithdrawalLimit(100);
+		assertThrows(IllegalStateException.class, () -> {
+			testAccount.withdraw(150);
+		});
+		assertEquals(500, testAccount.getBalance(), 0.01);
+	}
+
+	// 45. Multiple withdrawals that together exceed the limit should throw on the last one
+	@Test
+	void testCumulativeDailyWithdrawalsBlockedWhenExceeded() {
+		testAccount.deposit(500);
+		testAccount.setDailyWithdrawalLimit(100);
+		testAccount.withdraw(60);
+		assertThrows(IllegalStateException.class, () -> {
+			testAccount.withdraw(50);
+		});
+		assertEquals(440, testAccount.getBalance(), 0.01);
+		assertEquals(60, testAccount.getDailyWithdrawalUsedToday(), 0.01);
+	}
+
+	// 46. Used-today should reset to zero after clearing the limit
+	@Test
+	void testClearResetsUsedToday() {
+		testAccount.deposit(500);
+		testAccount.setDailyWithdrawalLimit(200);
+		testAccount.withdraw(100);
+		testAccount.clearDailyWithdrawalLimit();
+		assertEquals(0, testAccount.getDailyWithdrawalUsedToday(), 0.01);
+	}
+
+	// 47. With no daily limit, remaining should be effectively unlimited
+	@Test
+	void testDailyRemainingWithoutLimit() {
+		assertEquals(Double.MAX_VALUE, testAccount.getDailyWithdrawalRemaining(), 0.01);
+	}
+
 }


### PR DESCRIPTION
Closes #50

Customers can set a self-imposed daily withdrawal limit. Withdrawals that would push the running total over the limit are blocked. The limit can be added, changed, or removed from the menu. Applies to standard, checking, and savings account types.